### PR TITLE
feat(progress): add calories bar chart to Progress tab

### DIFF
--- a/routes/progress.py
+++ b/routes/progress.py
@@ -134,6 +134,25 @@ def get_progress():
         for r in reversed(water_rows)
     ]
 
+    # Nutrition history — last 7 days summed by date
+    nutrition_rows = db.execute("""
+        SELECT date, SUM(calories) as total_calories, SUM(protein) as total_protein,
+               SUM(carbs) as total_carbs, SUM(fat) as total_fat
+        FROM nutrition_logs
+        WHERE user_id = ?
+        GROUP BY date
+        ORDER BY date DESC
+        LIMIT 7
+    """, (user_id,)).fetchall()
+
+    nutrition_history = [
+        {"date": r["date"], "calories": round(r["total_calories"] or 0),
+         "protein": round(r["total_protein"] or 0),
+         "carbs": round(r["total_carbs"] or 0),
+         "fat": round(r["total_fat"] or 0)}
+        for r in reversed(nutrition_rows)
+    ]
+
     db.close()
 
     return jsonify({
@@ -144,4 +163,5 @@ def get_progress():
         "streak_weeks": streak,
         "sleep_history": sleep_history,
         "water_history": water_history,
+        "nutrition_history": nutrition_history,
     })

--- a/templates/app.html
+++ b/templates/app.html
@@ -535,6 +535,12 @@
                 <div id="progress-water"></div>
             </div>
 
+            <!-- Nutrition Chart -->
+            <div class="card">
+                <div class="card-title">🍽️ Калорії</div>
+                <div id="progress-nutrition"></div>
+            </div>
+
             <!-- Measurements -->
             <div class="card">
                 <div class="card-title">📏 Вимірювання</div>
@@ -1622,6 +1628,30 @@
                     waterEl.innerHTML = '<svg viewBox="0 0 ' + W + ' ' + H + '" style="width:100%;height:auto;display:block;" xmlns="http://www.w3.org/2000/svg">' + bars + '</svg>';
                 } else {
                     waterEl.innerHTML = '<div style="color:#888;font-size:13px">Немає даних про воду</div>';
+                }
+
+                // Nutrition — horizontal bar chart (last 7 days)
+                const nutrEl = document.getElementById('progress-nutrition');
+                const nh = d.nutrition_history || [];
+                if (nh.length > 0) {
+                    const maxCal = Math.max.apply(null, nh.map(function(n) { return n.calories || 0; }));
+                    const avgCal = Math.round(nh.reduce(function(s, n) { return s + (n.calories || 0); }, 0) / nh.length);
+                    const W = 340, H = nh.length * 40 + 24, PAD = 8;
+                    const barH = 20;
+                    let bars = '';
+                    nh.forEach(function(n, i) {
+                        var y = PAD + i * 40;
+                        var pct = maxCal > 0 ? (n.calories / maxCal) : 0;
+                        var barW = pct * (W - PAD * 2 - 60);
+                        var fillColor = '#f59e0b';
+                        bars += '<rect x="' + PAD + '" y="' + y + '" width="' + barW.toFixed(1) + '" height="' + barH + '" rx="4" fill="' + fillColor + '" opacity="0.8"/>';
+                        bars += '<text x="' + (PAD + barW + 6) + '" y="' + (y + 14) + '" fill="#888" font-size="11">' + n.calories + ' ккал</text>';
+                        bars += '<text x="' + (W - PAD) + '" y="' + (y + 14) + '" text-anchor="end" fill="#aaa" font-size="10">' + (n.date || '').substring(5) + '</text>';
+                    });
+                    bars += '<text x="' + PAD + '" y="' + (H - 4) + '" fill="#aaa" font-size="10">Середнє: ' + avgCal + ' ккал/день</text>';
+                    nutrEl.innerHTML = '<svg viewBox="0 0 ' + W + ' ' + H + '" style="width:100%;height:auto;display:block;" xmlns="http://www.w3.org/2000/svg">' + bars + '</svg>';
+                } else {
+                    nutrEl.innerHTML = '<div style="color:#888;font-size:13px">Немає даних про харчування</div>';
                 }
 
                 // Measurements — SVG line charts


### PR DESCRIPTION
Add a nutrition/calories trend chart to the Progress tab showing the last 7 days of daily calorie intake.\n\nChanges:\n- Progress API now returns nutrition_history (last 7 days summed from nutrition_logs)\n- New card in Progress tab: 🍽️ Калорії with horizontal SVG bar chart\n- Shows average daily calories at bottom